### PR TITLE
mimic int overflow in java

### DIFF
--- a/lib/resty/rocketmq/utils.lua
+++ b/lib/resty/rocketmq/utils.lua
@@ -254,6 +254,7 @@ function _M.java_hash(s)
     local h = 0
     for i = 1, #s do
         h = 31 * h + byte(s, i);
+        h = band(2^32-1, h)
     end
     return h
 end


### PR DESCRIPTION
Java中hashcode是int，超过2^32会溢出；lua中的number对应Java中的double，超过2^32不会溢出；lua的bit库底层是C语言的int，用bit.and可以模拟int溢出